### PR TITLE
Implement auth with Redux and middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// Middleware para verificar si el usuario está autenticado mediante una cookie
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('token')?.value
+  const { pathname } = req.nextUrl
+
+  if (pathname.startsWith('/home')) {
+    if (!token) {
+      const url = req.nextUrl.clone()
+      url.pathname = '/login'
+      return NextResponse.redirect(url)
+    }
+  }
+
+  if (pathname.startsWith('/login') && token) {
+    const url = req.nextUrl.clone()
+    url.pathname = '/home'
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  // Rutas que deben pasar por el middleware
+  matcher: ['/home/:path*', '/login'],
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.2"
+    "next": "15.3.2",
+    "@reduxjs/toolkit": "^2.2.3",
+    "react-redux": "^9.1.3",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAppDispatch } from "@/store/hooks";
+import { logout } from "@/store/authSlice";
+
+export default function HomePage() {
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  // Cierra la sesión eliminando datos y redirigiendo al login
+  const handleLogout = () => {
+    dispatch(logout());
+    document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    router.push("/login");
+  };
+
+  return (
+    <div className="min-h-screen inter-font">
+      <nav className="p-4 bg-[#262626] text-white flex justify-between items-center">
+        <span className="font-bold">Home</span>
+        {/* Menú simple con opción para cerrar sesión */}
+        <div className="relative">
+          <button onClick={() => setOpen(!open)} className="px-3 py-1 bg-[#e3132d] rounded">
+            Menú
+          </button>
+          {open && (
+            <ul className="absolute right-0 mt-2 bg-white text-black rounded shadow">
+              <li>
+                <button
+                  className="block px-4 py-2 hover:bg-gray-200 w-full text-left"
+                  onClick={handleLogout}
+                >
+                  Cerrar sesión
+                </button>
+              </li>
+            </ul>
+          )}
+        </div>
+      </nav>
+      <div className="p-4 text-white">Bienvenido al sistema</div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Providers from "@/store/Providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="es">
       <body className="bg-[url(/fondo_1.png)] bg-cover">
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+import Image from "next/image";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAppDispatch } from "@/store/hooks";
+import { setCredentials } from "@/store/authSlice";
+
+// Página de inicio de sesión
+
+export default function LoginPage() {
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+  const [usuario, setUsuario] = useState("");
+  const [clave, setClave] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Función para enviar las credenciales al backend y procesar la respuesta
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch("http://localhost:8000/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ usuario, clave }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.mensajeRespuesta) {
+        setError(data.mensajeRespuesta || "Error al iniciar sesión");
+        return;
+      }
+      // Guardamos los tokens en Redux y en una cookie para que el middleware pueda validar
+      dispatch(setCredentials({ token: data.token, refresh_token: data.refresh_token }));
+      document.cookie = `token=${data.token}; path=/`;
+      router.push("/home");
+    } catch (err) {
+      setError("Error de conexión con el servidor");
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen inter-font">
+      <div className="login-wrapper">
+        {/* Falta el responsive de aqui para abajo */}
+        <div className="w-md p-6 pb-8 bg-[#262626] bg-opacity-50 rounded-lg shadow-lg">
+          <div className="w-full">
+            <Image
+              className="mx-auto mb-3"
+              src="/ube-logo-texto.png"
+              alt="UBE-LOGO"
+              width={220}
+              height={45}
+              priority
+            />
+          </div>
+
+          <div className="mb-5 mt-5">
+            <p className="text-center text-xl text-white inter-font font-bold">MARKETPLACE UNIVERSITARIO</p>
+          </div>
+
+          {error && (
+            <p className="text-center text-red-500 font-bold" data-testid="error-msg">
+              {error}
+            </p>
+          )}
+
+          <form className="space-y-4 pl-5 pr-5 form-login" onSubmit={handleSubmit}>
+            <div className="input-group">
+              <label htmlFor="usuario">Usuario</label>
+              <input
+                type="text"
+                name="usuario"
+                placeholder="Usuario"
+                className="input-form"
+                autoComplete="off"
+                value={usuario}
+                onChange={(e) => setUsuario(e.target.value)}
+              />
+            </div>
+
+            <div className="input-group">
+              <label htmlFor="password">Contraseña</label>
+              <input
+                type="password"
+                name="password"
+                placeholder="Contraseña"
+                className="input-form"
+                autoComplete="off"
+                value={clave}
+                onChange={(e) => setClave(e.target.value)}
+              />
+            </div>
+
+            <div className="input-group">
+              <a href="#" className="text-md">
+                ¿Olvidaste tu contraseña?
+              </a>
+
+              <button
+                type="submit"
+                className="mt-2 w-full py-2 bg-[#e3132d] text-md text-white rounded hover:bg-[#BF0F27] transition cursor-pointer"
+              >
+                Iniciar sesión
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div className="w-md p-6 bg-[#262626] bg-opacity-50 rounded-lg shadow-lg">
+          <h2 className="text-center text-xl font-bold mb-4 text-[#e3132d]">¿Aún no tienes cuenta?</h2>
+          <p className="text-md text-center text-white">
+            Carreras de pre y post grado, cursos, diplomados, pasantías, etc. Todo en un solo lugar, para ti.
+          </p>
+
+          <button
+            type="button"
+            className="mt-3 w-full py-2 bg-[#e3132d] text-md text-white rounded hover:bg-[#BF0F27] transition cursor-pointer"
+          >
+            Crear cuenta
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,99 +1,20 @@
-import Image from "next/image";
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAppSelector } from "@/store/hooks";
 
-export default function Home() {
-	return (
+// Página inicial que redirige según el estado de autenticación
+export default function Index() {
+  const token = useAppSelector((state) => state.auth.token);
+  const router = useRouter();
 
-		<div className="relative min-h-screen inter-font">
+  useEffect(() => {
+    if (token) {
+      router.replace('/home')
+    } else {
+      router.replace('/login')
+    }
+  }, [token, router]);
 
-
-			<div className="login-wrapper">
-
-				{/* Falta el responsive de aqui para abajo */}
-				<div className="w-md p-6 pb-8 bg-[#262626] bg-opacity-50 rounded-lg shadow-lg">
-
-					<div className="w-full">
-						<Image
-							className="mx-auto mb-3"
-							src="/ube-logo-texto.png"
-							alt="UBE-LOGO"
-							width={220}
-							height={45}
-							priority
-						/>
-					</div>
-
-					<div className="mb-5 mt-5">
-						<p className="text-center text-xl text-white inter-font font-bold">
-							MARKETPLACE UNIVERSITARIO
-						</p>
-					</div>
-
-
-					<form className="space-y-4 pl-5 pr-5 form-login">
-
-						<div className="input-group">
-							<label htmlFor="email">Correo electrónico</label>
-							<input
-								type="email"
-								name="email"
-								placeholder="Correo electrónico"
-								className="input-form"
-								autoComplete="off"
-							/>
-						</div>
-
-
-						<div className="input-group">
-							<label htmlFor="password">Contraseña</label>
-							<input
-								type="password"
-								name="password"
-								placeholder="Contraseña"
-								className="input-form"
-								autoComplete="off"
-							/>
-						</div>
-
-						<div className="input-group">
-							<a href="#" className="text-md">
-								¿Olvidaste tu contraseña?
-							</a>
-
-							<button
-								type="submit"
-								className="mt-2 w-full py-2 bg-[#e3132d] text-md text-white rounded hover:bg-[#BF0F27] transition cursor-pointer"
-							>
-								Iniciar sesión
-							</button>
-						</div>
-
-					</form>
-				</div>
-
-				<div className="w-md p-6 bg-[#262626] bg-opacity-50 rounded-lg shadow-lg">
-
-					<h2 className="text-center text-xl font-bold mb-4 text-[#e3132d]">
-						¿Aún no tienes cuenta?
-					</h2>
-					<p className="text-md text-center text-white">
-						Carreras de pre y post grado, cursos, diplomados, pasantías, etc. Todo en un solo lugar, para ti.
-					</p>
-
-					<button
-						type="submit"
-						className="mt-3 w-full py-2 bg-[#e3132d] text-md text-white rounded hover:bg-[#BF0F27] transition cursor-pointer"
-					>
-						Crear cuenta
-					</button>
-				</div>
-
-
-
-			</div>
-		</div>
-
-
-
-
-	);
+  return null;
 }

--- a/src/store/Providers.tsx
+++ b/src/store/Providers.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { Provider } from 'react-redux'
+import { PersistGate } from 'redux-persist/integration/react'
+import { store, persistor } from './store'
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  // Envolvemos la aplicación con Redux y redux-persist
+  return (
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        {children}
+      </PersistGate>
+    </Provider>
+  )
+}

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,0 +1,35 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+// Estado de autenticación a almacenar en Redux
+interface AuthState {
+  token: string | null
+  refresh_token: string | null
+}
+
+const initialState: AuthState = {
+  token: null,
+  refresh_token: null,
+}
+
+export const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    // Guarda los tokens proporcionados por el backend
+    setCredentials: (
+      state,
+      action: PayloadAction<{ token: string; refresh_token: string }>
+    ) => {
+      state.token = action.payload.token
+      state.refresh_token = action.payload.refresh_token
+    },
+    // Limpia la información de sesión
+    logout: (state) => {
+      state.token = null
+      state.refresh_token = null
+    },
+  },
+})
+
+export const { setCredentials, logout } = authSlice.actions
+export default authSlice.reducer

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import type { RootState, AppDispatch } from './store'
+
+// Atajos tipados para usar dispatch y selector en componentes
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,30 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { persistReducer, persistStore } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
+import { combineReducers } from 'redux'
+import authReducer from './authSlice'
+
+// Configuración de persistencia utilizando localStorage
+const rootPersistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['auth'],
+}
+
+const rootReducer = combineReducers({
+  auth: authReducer,
+})
+
+// Reducer combinado con persistencia
+const persistedReducer = persistReducer(rootPersistConfig, rootReducer)
+
+// Creación del store de Redux
+export const store = configureStore({
+  reducer: persistedReducer,
+})
+
+// Instancia que controla la rehidratación del estado
+export const persistor = persistStore(store)
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch


### PR DESCRIPTION
## Summary
- add Redux Toolkit store with persistency
- implement login page with API call
- redirect unauthenticated access using middleware
- create protected home page with logout
- wrap layout with Redux providers

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e522bde4832daa63d0a270f3283c